### PR TITLE
Remove eirini-controller resource

### DIFF
--- a/pipelines/clusters/pipeline.yml
+++ b/pipelines/clusters/pipeline.yml
@@ -87,7 +87,6 @@ jobs:
     - get: korifi-ci
     - get: cf-k8s-secrets
     - get: korifi
-    - get: eirini-controller
   - get: semver-event-pr-e2e
     passed:
     - create-cluster-pr-e2e
@@ -137,13 +136,6 @@ resources:
   source:
     uri: https://github.com/cloudfoundry/korifi.git
     branch: main
-
-- name: eirini-controller
-  type: git
-  icon: git
-  source:
-    uri: https://github.com/cloudfoundry/eirini-controller.git
-    branch: master
 
 - name: delete-timer
   type: time

--- a/pipelines/pr-e2e/pipeline.yml
+++ b/pipelines/pr-e2e/pipeline.yml
@@ -62,7 +62,6 @@ jobs:
       trigger: true
       version: every
     - get: cf-k8s-secrets
-    - get: eirini-controller
 
   - put: korifi-pr
     params:
@@ -188,13 +187,6 @@ resources:
     uri: ((github/cf-k8s-secrets.uri))
     branch: main
     private_key: ((github/cf-k8s-secrets.private_key))
-
-- name: eirini-controller
-  type: git
-  icon: git
-  source:
-    uri: https://github.com/cloudfoundry/eirini-controller.git
-    branch: master
 
 - name: slack
   type: slack-notification

--- a/pipelines/tasks/install-korifi-dependencies.yml
+++ b/pipelines/tasks/install-korifi-dependencies.yml
@@ -2,7 +2,6 @@ platform: linux
 inputs:
 - name: korifi-ci
 - name: korifi
-- name: eirini-controller
 - name: terraform-output
 params:
   CLUSTER_NAME:


### PR DESCRIPTION
The install-dependencies script now installs eirini from the github
release, so we don't install from latest on master

Co-authored-by: Kieron Browne <kbrowne@vmware.com>