### PR TITLE
Print contour logs on E2E failure

### DIFF
--- a/pipelines/main/pipeline.yml
+++ b/pipelines/main/pipeline.yml
@@ -143,6 +143,10 @@ jobs:
         - state: failure
           context: "Concourse - E2E (main)"
     - *slackHook
+    - task: get-contour-logs
+      file: korifi-ci/pipelines/tasks/get-contour-logs.yml
+      image: ci-image
+
   serial: true
   serial_groups:
   - pr-e2e
@@ -368,7 +372,11 @@ jobs:
 
 - name: run-e2es-periodic
   on_failure:
-    *slackHook
+    do:
+    - *slackHook
+    - task: get-contour-logs
+      file: korifi-ci/pipelines/tasks/get-contour-logs.yml
+      image: ci-image
   serial: true
   serial_groups:
   - pr-e2e

--- a/pipelines/scripts/get-contour-logs.sh
+++ b/pipelines/scripts/get-contour-logs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source korifi-ci/pipelines/scripts/common/gcloud-functions
+
+generate_kube_config() {
+  gcloud-login
+  export-kubeconfig "$CLUSTER_NAME"
+}
+
+main() {
+  export KUBECONFIG=$PWD/kube/kube.config
+  generate_kube_config
+  kubectl -n projectcontour logs deployments/contour --all-containers=true --since 20m
+}
+
+main

--- a/pipelines/tasks/get-contour-logs.yml
+++ b/pipelines/tasks/get-contour-logs.yml
@@ -1,0 +1,9 @@
+platform: linux
+
+params:
+  GCP_SERVICE_ACCOUNT_JSON: ((gcp-serviceaccount))
+  GCP_ZONE:
+  CLUSTER_NAME:
+
+run:
+  path: korifi-ci/pipelines/scripts/get-contour-logs.sh


### PR DESCRIPTION
This is hopefully useful to investigate connectivity issues, such as
`upstream connect error or disconnect/reset before headers. reset
reason: connection failure`

Issue: https://github.com/cloudfoundry/korifi/issues/1310
