### PR TITLE
Add chmod buildpack to Ruby group on Acceptance env

### DIFF
--- a/pipelines/main/pipeline.yml
+++ b/pipelines/main/pipeline.yml
@@ -651,6 +651,13 @@ jobs:
 
   - do: *deploy-korifi
   - do: *set-account-env-vars
+  - task: add-chmod-buildpack-for-rails
+    file: korifi-ci/pipelines/tasks/add-chmod-rails-buildpack.yml
+    image: ci-image
+    params:
+      CLUSTER_NAME: ((.:cluster-env-vars.CLUSTER_NAME))
+      CLUSTER_TYPE: ((.:cluster-env-vars.CLUSTER_TYPE))
+      GCP_ZONE: ((.:cluster-env-vars.GCP_ZONE))
   - do: *smoke-tests
 
 - name: deploy-pairup

--- a/pipelines/scripts/add-chmod-rails-buildpack.sh
+++ b/pipelines/scripts/add-chmod-rails-buildpack.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This is a temporary workaround to address the following issue with the Jammy stack and Rails apps.
+# Once the Ruby buildpack fixes this we can remove this step from our pipeline.
+# https://github.com/paketo-buildpacks/ruby/issues/889
+
+set -euo pipefail
+
+source korifi-ci/pipelines/scripts/common/gcloud-functions
+
+export-kubeconfig
+
+# The source for our chmod buildpack lives here: https://github.com/eirini-forks/chmod-buildpack
+echo "Adding korifi/chmod buildpack to ClusterStore"
+kubectl patch clusterstore cf-default-buildpacks --type='json' -p='[{ "op": "add", "path": "/spec/sources/-", "value": { "image": "us-west1-docker.pkg.dev/cf-on-k8s-wg/buildpacks/chmod:latest" } }]'
+
+echo "Adding korifi/chmod buildpack to Ruby group under ClusterBuilder"
+updated_order="$(kubectl get clusterbuilder cf-kpack-cluster-builder -o json | jq '.spec.order[] | select(.group[].id=="paketo-buildpacks/ruby").group |= [{"id": "korifi/chmod"}] + .' | jq -n '.spec.order |= [inputs]')"
+kubectl patch clusterbuilder cf-kpack-cluster-builder -p "$updated_order" --type=merge
+

--- a/pipelines/tasks/add-chmod-rails-buildpack.yml
+++ b/pipelines/tasks/add-chmod-rails-buildpack.yml
@@ -1,0 +1,13 @@
+platform: linux
+
+inputs:
+- name: korifi-ci
+
+params:
+  GCP_SERVICE_ACCOUNT_JSON: ((gcp-serviceaccount))
+  CLUSTER_NAME:
+  CLUSTER_TYPE:
+  GCP_ZONE:
+
+run:
+  path: korifi-ci/pipelines/scripts/add-chmod-rails-buildpack.sh


### PR DESCRIPTION
This change adds a [chmod buildpack](https://github.com/eirini-forks/chmod-buildpack) to the Ruby group on the Acceptance environment which will allow us to build Postfacto using the Jammy stack. It's a temporary change that we should undo once the Ruby buildpack supports this usecase on Jammy natively.

See the following for more context on the issue:
* Slack thread: https://cloudfoundry.slack.com/archives/C0297673ASK/p1689943895064839?thread_ts=1689892277.909709&cid=C0297673ASK
* https://github.com/paketo-buildpacks/ruby/issues/889